### PR TITLE
create player service

### DIFF
--- a/.idea/deploymentTargetDropDown.xml
+++ b/.idea/deploymentTargetDropDown.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetDropDown">
+    <targetSelectedWithDropDown>
+      <Target>
+        <type value="QUICK_BOOT_TARGET" />
+        <deviceKey>
+          <Key>
+            <type value="VIRTUAL_DEVICE_PATH" />
+            <value value="$USER_HOME$/.android/avd/Pixel_3a_API_30.avd" />
+          </Key>
+        </deviceKey>
+      </Target>
+    </targetSelectedWithDropDown>
+    <timeTargetWasSelectedWithDropDown value="2023-03-16T12:17:25.045613Z" />
+  </component>
+</project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,8 @@
 plugins {
     id 'com.android.application'
     id 'org.jetbrains.kotlin.android'
+    id 'kotlin-kapt'
+    id 'dagger.hilt.android.plugin'
 }
 
 android {
@@ -64,4 +66,10 @@ dependencies {
     // Video Player
     implementation 'androidx.media3:media3-exoplayer:1.0.0-rc02'
     implementation 'androidx.media3:media3-ui:1.0.0-rc02'
+
+    //Dagger - Hilt
+    implementation 'com.google.dagger:hilt-android:2.43.2'
+    kapt 'com.google.dagger:hilt-android-compiler:2.43.2'
+    kapt "androidx.hilt:hilt-compiler:1.0.0"
+    implementation 'androidx.hilt:hilt-navigation-compose:1.0.0'
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <application
+        android:name=".MediaPlayerApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,12 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools">
 
+    <!-- Internet permission -->
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
+        android:usesCleartextTraffic="true"
         android:name=".MediaPlayerApp"
         android:allowBackup="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
@@ -28,6 +33,7 @@
                 android:name="android.app.lib_name"
                 android:value="" />
         </activity>
+        <service android:name=".common.service.PlayerService" android:foregroundServiceType="mediaPlayback"/>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/seongju/composemediaplayer/MainActivity.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/MainActivity.kt
@@ -11,7 +11,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.seongju.composemediaplayer.ui.theme.ComposeMediaPlayerTheme
+import dagger.hilt.android.AndroidEntryPoint
 
+@AndroidEntryPoint
 class MainActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,22 +24,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-                    Greeting("Android")
+
                 }
             }
         }
-    }
-}
-
-@Composable
-fun Greeting(name: String) {
-    Text(text = "Hello $name!")
-}
-
-@Preview(showBackground = true)
-@Composable
-fun DefaultPreview() {
-    ComposeMediaPlayerTheme {
-        Greeting("Android")
     }
 }

--- a/app/src/main/java/com/seongju/composemediaplayer/MainActivity.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/MainActivity.kt
@@ -1,6 +1,8 @@
 package com.seongju.composemediaplayer
 
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.fillMaxSize
@@ -10,11 +12,19 @@ import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
+import com.seongju.composemediaplayer.common.service.ServiceManager
+import com.seongju.composemediaplayer.presentation.player.VideoScreen
 import com.seongju.composemediaplayer.ui.theme.ComposeMediaPlayerTheme
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.delay
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
+    @Inject
+    lateinit var serviceManager: ServiceManager
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
@@ -24,7 +34,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colors.background
                 ) {
-
+                    if (serviceManager.playerServiceState.value) {
+                        VideoScreen(serviceManager = serviceManager)
+                    }
                 }
             }
         }

--- a/app/src/main/java/com/seongju/composemediaplayer/MainActivity.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/MainActivity.kt
@@ -1,22 +1,23 @@
 package com.seongju.composemediaplayer
 
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.CircularProgressIndicator
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Surface
 import androidx.compose.material.Text
-import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 import com.seongju.composemediaplayer.common.service.ServiceManager
 import com.seongju.composemediaplayer.presentation.player.VideoScreen
 import com.seongju.composemediaplayer.ui.theme.ComposeMediaPlayerTheme
 import dagger.hilt.android.AndroidEntryPoint
-import kotlinx.coroutines.delay
 import javax.inject.Inject
 
 @AndroidEntryPoint
@@ -36,6 +37,21 @@ class MainActivity : ComponentActivity() {
                 ) {
                     if (serviceManager.playerServiceState.value) {
                         VideoScreen(serviceManager = serviceManager)
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
+                            Text(
+                                text = "Player Service 를 시작 중 입니다."
+                            )
+                            Spacer(
+                                modifier = Modifier
+                                    .height(20.dp)
+                            )
+                            CircularProgressIndicator()
+                        }
                     }
                 }
             }

--- a/app/src/main/java/com/seongju/composemediaplayer/MediaPlayerApp.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/MediaPlayerApp.kt
@@ -1,0 +1,13 @@
+package com.seongju.composemediaplayer
+
+import android.app.Application
+import dagger.hilt.android.HiltAndroidApp
+
+@HiltAndroidApp
+class MediaPlayerApp: Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+    }
+
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/common/Constants.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/Constants.kt
@@ -1,0 +1,9 @@
+package com.seongju.composemediaplayer.common
+
+object Constants {
+
+    const val PLAYER_URI = "play to video uri"
+    const val ACTION_VIDEO_START = "video play start"
+    const val ACTION_VIDEO_STOP = "video play stop"
+
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/common/Constants.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/Constants.kt
@@ -3,7 +3,9 @@ package com.seongju.composemediaplayer.common
 object Constants {
 
     const val PLAYER_URI = "play to video uri"
-    const val ACTION_VIDEO_START = "video play start"
-    const val ACTION_VIDEO_STOP = "video play stop"
+    const val ACTION_VIDEO_START = "video play Start"
+    const val ACTION_VIDEO_STOP = "video play Stop"
+    const val ACTION_VIDEO_PAUSE = "video play onPause"
+    const val ACTION_VIDEO_RESUME = "video play onResume"
 
 }

--- a/app/src/main/java/com/seongju/composemediaplayer/common/service/PlayerService.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/service/PlayerService.kt
@@ -8,6 +8,8 @@ import android.util.Log
 import androidx.compose.runtime.mutableStateOf
 import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
+import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_PAUSE
+import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_RESUME
 import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_START
 import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_STOP
 import com.seongju.composemediaplayer.common.Constants.PLAYER_URI
@@ -56,6 +58,14 @@ class PlayerService: Service() {
         videoClient.stopPlay()
     }
 
+    private fun pauseVideoPlay(){
+        videoClient.pausePlay()
+    }
+
+    private fun resumeVideoPlay(){
+        videoClient.resumePlay()
+    }
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when(intent?.action) {
             ACTION_VIDEO_START -> {
@@ -73,6 +83,12 @@ class PlayerService: Service() {
             }
             ACTION_VIDEO_STOP -> {
                 stopVideoPlay()
+            }
+            ACTION_VIDEO_PAUSE -> {
+                pauseVideoPlay()
+            }
+            ACTION_VIDEO_RESUME -> {
+                resumeVideoPlay()
             }
         }
         return super.onStartCommand(intent, flags, startId)

--- a/app/src/main/java/com/seongju/composemediaplayer/common/service/PlayerService.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/service/PlayerService.kt
@@ -65,7 +65,7 @@ class PlayerService: Service() {
                     return START_NOT_STICKY
                 }
 
-                if (playerState.value == PlayerStatus.STATE_ENDED) {
+                if (playerState.value != PlayerStatus.STATE_ENDED) {
                     Log.e(tag, "이미 영상이 재생중 입니다.")
                     return START_NOT_STICKY
                 }

--- a/app/src/main/java/com/seongju/composemediaplayer/common/service/PlayerService.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/service/PlayerService.kt
@@ -1,0 +1,106 @@
+package com.seongju.composemediaplayer.common.service
+
+import android.app.Service
+import android.content.Intent
+import android.os.Binder
+import android.os.IBinder
+import android.util.Log
+import androidx.compose.runtime.mutableStateOf
+import androidx.media3.common.Player
+import androidx.media3.exoplayer.ExoPlayer
+import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_START
+import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_STOP
+import com.seongju.composemediaplayer.common.Constants.PLAYER_URI
+import com.seongju.composemediaplayer.data.player.VideoPlayer
+import com.seongju.composemediaplayer.domain.player.PlayerClient
+import com.seongju.composemediaplayer.domain.player.PlayerResult
+import com.seongju.composemediaplayer.domain.player.PlayerStatus
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
+
+class PlayerService: Service() {
+
+    private val tag = "PlayerService"
+    private val binder: IBinder = LocalBinder()
+
+    private val serviceVideoScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+    private lateinit var videoClient: PlayerClient
+
+    lateinit var player: Player
+        private set
+    var playerState = mutableStateOf(PlayerStatus.STATE_ENDED)
+        private set
+
+    private fun startVideoPlay(uri: String) {
+        videoClient.startPlay(uri = uri)
+            .catch { e -> e.printStackTrace() }
+            .onEach { playerResult ->
+                when(playerResult) {
+                    is PlayerResult.Error -> {
+                        Log.e(tag, playerResult.message)
+                    }
+                    is PlayerResult.Status -> {
+                        playerState.value = playerResult.status
+                    }
+                }
+            }.launchIn(serviceVideoScope)
+    }
+
+    private fun stopVideoPlay(){
+        videoClient.stopPlay()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        when(intent?.action) {
+            ACTION_VIDEO_START -> {
+                val videoUri = intent.getStringExtra(PLAYER_URI)
+                if (videoUri == null) {
+                    Log.e(tag, "영상 URI 를 받지 못하였습니다.")
+                    return START_NOT_STICKY
+                }
+
+                if (playerState.value == PlayerStatus.STATE_ENDED) {
+                    Log.e(tag, "이미 영상이 재생중 입니다.")
+                    return START_NOT_STICKY
+                }
+                startVideoPlay(videoUri)
+            }
+            ACTION_VIDEO_STOP -> {
+                stopVideoPlay()
+            }
+        }
+        return super.onStartCommand(intent, flags, startId)
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        player = ExoPlayer.Builder(applicationContext)
+            .build()
+        videoClient = VideoPlayer(
+            player = player
+        )
+    }
+
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceVideoScope.cancel()
+    }
+
+    override fun onBind(intent: Intent?): IBinder {
+        return binder
+    }
+
+    inner class LocalBinder(): Binder() {
+        fun getPlayerService(
+
+        ): PlayerService {
+            return this@PlayerService
+        }
+    }
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceHelper.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceHelper.kt
@@ -20,4 +20,11 @@ object ServiceHelper {
             context.startService(this)
         }
     }
+
+    fun triggerVideoPlay(context: Context, action: String) {
+        Intent(context, PlayerService::class.java).apply {
+            this.action = action
+            context.startService(this)
+        }
+    }
 }

--- a/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceHelper.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceHelper.kt
@@ -1,0 +1,23 @@
+package com.seongju.composemediaplayer.common.service
+
+import android.content.Context
+import android.content.Intent
+import com.seongju.composemediaplayer.common.Constants.PLAYER_URI
+
+object ServiceHelper {
+
+    fun startVideoPlay(context: Context, action: String, uri: String) {
+        Intent(context, PlayerService::class.java).apply {
+            this.action = action
+            this.putExtra(PLAYER_URI, uri)
+            context.startService(this)
+        }
+    }
+
+    fun stopVideoPlay(context: Context, action: String) {
+        Intent(context, PlayerService::class.java).apply {
+            this.action = action
+            context.startService(this)
+        }
+    }
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceManager.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceManager.kt
@@ -6,6 +6,7 @@ import android.content.Intent
 import android.content.ServiceConnection
 import android.os.IBinder
 import android.util.Log
+import androidx.compose.runtime.mutableStateOf
 
 class ServiceManager(
     private val context: Context
@@ -17,6 +18,9 @@ class ServiceManager(
         private set
 
     private lateinit var playerServiceConnection: ServiceConnection
+
+    var playerServiceState = mutableStateOf(false)
+        private set
 
     init {
         initServiceConnection()
@@ -48,6 +52,7 @@ class ServiceManager(
             override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
                 val getPlayerService = service as PlayerService.LocalBinder
                 playerService = getPlayerService.getPlayerService()
+                playerServiceState.value = true
                 Log.d(tag, "Player Service 실행에 성공하였습니다.")
             }
 

--- a/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceManager.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/common/service/ServiceManager.kt
@@ -1,0 +1,61 @@
+package com.seongju.composemediaplayer.common.service
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.ServiceConnection
+import android.os.IBinder
+import android.util.Log
+
+class ServiceManager(
+    private val context: Context
+) {
+
+    private val tag = "ServiceManager"
+
+    lateinit var playerService: PlayerService
+        private set
+
+    private lateinit var playerServiceConnection: ServiceConnection
+
+    init {
+        initServiceConnection()
+    }
+
+    fun startPlayerService() {
+        if (!::playerService.isInitialized) {
+            val intent = Intent(context, PlayerService::class.java)
+            context.bindService(intent, playerServiceConnection, Context.BIND_AUTO_CREATE)
+        } else {
+            Log.e(tag, "Player Service 가 초기화 되어있습니다.")
+        }
+    }
+
+    fun stopPlayerService() {
+        if (::playerService.isInitialized) {
+            context.unbindService(playerServiceConnection)
+            Log.d(tag, "Player Service 종료에 성공하였습니다.")
+        } else {
+            Log.e(tag, "Player Service 종료에 실패하였습니다.")
+        }
+    }
+
+    /**
+     * Set Service Connections
+     */
+    private fun initServiceConnection() {
+        playerServiceConnection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, service: IBinder?) {
+                val getPlayerService = service as PlayerService.LocalBinder
+                playerService = getPlayerService.getPlayerService()
+                Log.d(tag, "Player Service 실행에 성공하였습니다.")
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                Log.e(tag, "Player Service 가 비정상적으로 종료되었습니다.")
+            }
+
+        }
+    }
+
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/data/player/VideoPlayer.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/data/player/VideoPlayer.kt
@@ -1,0 +1,90 @@
+package com.seongju.composemediaplayer.data.player
+
+import android.os.Handler
+import android.os.Looper
+import androidx.media3.common.PlaybackException
+import androidx.media3.common.Player
+import androidx.media3.common.Player.*
+import com.seongju.composemediaplayer.domain.player.PlayerClient
+import com.seongju.composemediaplayer.domain.player.PlayerResult
+import com.seongju.composemediaplayer.domain.player.PlayerStatus
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
+
+class VideoPlayer(
+    private val player: Player
+): PlayerClient {
+
+    private val tag: String = "VideoPlayer"
+    private val mainThreadHandler = Handler(Looper.getMainLooper())
+    private lateinit var playerListener: Listener
+
+    override fun startPlay(uri: String): Flow<PlayerResult> {
+        return callbackFlow {
+
+            playerListener = object : Listener {
+                override fun onPlayWhenReadyChanged(playWhenReady: Boolean, reason: Int) {
+                    super.onPlayWhenReadyChanged(playWhenReady, reason)
+
+                    if (playWhenReady) {
+                        launch { send(PlayerResult.Status(PlayerStatus.STATE_PLAYING)) }
+                    } else {
+                        launch { send(PlayerResult.Status(PlayerStatus.STATE_PAUSE)) }
+                    }
+                }
+
+                override fun onPlaybackStateChanged(playbackState: Int) {
+                    super.onPlaybackStateChanged(playbackState)
+
+                    when(playbackState) {
+                        STATE_ENDED -> {
+                            launch { send(PlayerResult.Status(PlayerStatus.STATE_ENDED)) }
+                        }
+                        STATE_BUFFERING -> {
+                            launch { send(PlayerResult.Status(PlayerStatus.STATE_BUFFERING)) }
+                        }
+                        STATE_IDLE -> {
+
+                        }
+                        STATE_READY -> {
+
+                        }
+                    }
+                }
+
+                override fun onPlayerError(error: PlaybackException) {
+                    super.onPlayerError(error)
+                    launch { send(PlayerResult.Error(message = error.toString()))}
+                }
+
+                override fun onPlayerErrorChanged(error: PlaybackException?) {
+                    super.onPlayerErrorChanged(error)
+                    launch { send(PlayerResult.Error(message = error.toString()))}
+                }
+            }
+
+            mainThreadHandler.post {
+                player.prepare()
+                player.addListener(playerListener)
+                player.play()
+            }
+
+            awaitClose {
+                mainThreadHandler.post{
+                    player.removeListener(playerListener)
+                    player.release()
+                }
+            }
+        }
+    }
+
+    override fun stopPlay() {
+        mainThreadHandler.post {
+            player.stop()
+            player.removeMediaItem(0)
+            player.removeListener(playerListener)
+        }
+    }
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/data/player/VideoPlayer.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/data/player/VideoPlayer.kt
@@ -89,4 +89,16 @@ class VideoPlayer(
             player.removeListener(playerListener)
         }
     }
+
+    override fun pausePlay() {
+        mainThreadHandler.post {
+            player.pause()
+        }
+    }
+
+    override fun resumePlay() {
+        mainThreadHandler.post {
+            player.play()
+        }
+    }
 }

--- a/app/src/main/java/com/seongju/composemediaplayer/data/player/VideoPlayer.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/data/player/VideoPlayer.kt
@@ -2,6 +2,7 @@ package com.seongju.composemediaplayer.data.player
 
 import android.os.Handler
 import android.os.Looper
+import androidx.media3.common.MediaItem
 import androidx.media3.common.PlaybackException
 import androidx.media3.common.Player
 import androidx.media3.common.Player.*
@@ -68,6 +69,7 @@ class VideoPlayer(
             mainThreadHandler.post {
                 player.prepare()
                 player.addListener(playerListener)
+                player.setMediaItem(MediaItem.fromUri(uri))
                 player.play()
             }
 

--- a/app/src/main/java/com/seongju/composemediaplayer/di/AppModule.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/di/AppModule.kt
@@ -1,6 +1,7 @@
 package com.seongju.composemediaplayer.di
 
 import android.app.Application
+import android.util.Log
 import com.seongju.composemediaplayer.common.service.ServiceManager
 import dagger.Module
 import dagger.Provides

--- a/app/src/main/java/com/seongju/composemediaplayer/di/AppModule.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/di/AppModule.kt
@@ -1,0 +1,23 @@
+package com.seongju.composemediaplayer.di
+
+import android.app.Application
+import com.seongju.composemediaplayer.common.service.ServiceManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+object AppModule {
+
+    @Provides
+    @Singleton
+    fun provideServiceManager(application: Application): ServiceManager {
+        return ServiceManager(context = application).also {
+            it.startPlayerService()
+        }
+    }
+
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerClient.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerClient.kt
@@ -1,0 +1,10 @@
+package com.seongju.composemediaplayer.domain.player
+
+import kotlinx.coroutines.flow.Flow
+
+interface PlayerClient {
+
+    fun startPlay(uri: String): Flow<PlayerResult>
+    fun stopPlay()
+
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerClient.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerClient.kt
@@ -6,5 +6,7 @@ interface PlayerClient {
 
     fun startPlay(uri: String): Flow<PlayerResult>
     fun stopPlay()
+    fun pausePlay()
+    fun resumePlay()
 
 }

--- a/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerResult.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerResult.kt
@@ -1,0 +1,6 @@
+package com.seongju.composemediaplayer.domain.player
+
+sealed interface PlayerResult{
+    data class Status(val status: PlayerStatus): PlayerResult
+    data class Error(val message: String): PlayerResult
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerStatus.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/domain/player/PlayerStatus.kt
@@ -1,0 +1,10 @@
+package com.seongju.composemediaplayer.domain.player
+
+enum class PlayerStatus {
+
+    STATE_PLAYING,
+    STATE_PAUSE,
+    STATE_BUFFERING,
+    STATE_ENDED
+
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/presentation/player/VideoScreen.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/presentation/player/VideoScreen.kt
@@ -1,0 +1,91 @@
+package com.seongju.composemediaplayer.presentation.player
+
+import android.content.res.Configuration.ORIENTATION_LANDSCAPE
+import android.content.res.Configuration.ORIENTATION_PORTRAIT
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.media3.common.Player
+import androidx.media3.ui.PlayerView
+import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_START
+import com.seongju.composemediaplayer.common.service.ServiceHelper
+import com.seongju.composemediaplayer.common.service.ServiceManager
+
+@Composable
+fun VideoScreen(
+    serviceManager: ServiceManager
+){
+    val localContext = LocalContext.current
+    val orientation = LocalContext.current.resources.configuration.orientation
+
+    LaunchedEffect(key1 = true) {
+        ServiceHelper.startVideoPlay(
+            context = localContext,
+            action = ACTION_VIDEO_START,
+            uri = "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4"
+        )
+    }
+
+    when(orientation) {
+        ORIENTATION_PORTRAIT -> {
+            VideoScreenBody(
+                player = serviceManager.playerService.player
+            )
+        }
+        ORIENTATION_LANDSCAPE -> {
+            VideoScreenFullBody(
+                player = serviceManager.playerService.player
+            )
+        }
+    }
+}
+
+@Composable
+fun VideoScreenBody(
+    player: Player
+){
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        AndroidView(
+            factory = {
+                context ->
+                PlayerView(context).also {
+                    it.player = player
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16 / 9f)
+        )
+    }
+}
+
+@Composable
+fun VideoScreenFullBody(
+    player: Player
+){
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+    ) {
+        AndroidView(
+            factory = {
+                    context ->
+                PlayerView(context).also {
+                    it.player = player
+                }
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(16 / 9f)
+        )
+    }
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/presentation/player/VideoScreen.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/presentation/player/VideoScreen.kt
@@ -2,6 +2,7 @@ package com.seongju.composemediaplayer.presentation.player
 
 import android.content.res.Configuration.ORIENTATION_LANDSCAPE
 import android.content.res.Configuration.ORIENTATION_PORTRAIT
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.Player
@@ -16,6 +18,8 @@ import androidx.media3.ui.PlayerView
 import com.seongju.composemediaplayer.common.Constants.ACTION_VIDEO_START
 import com.seongju.composemediaplayer.common.service.ServiceHelper
 import com.seongju.composemediaplayer.common.service.ServiceManager
+import com.seongju.composemediaplayer.presentation.util.hideSystemUI
+import com.seongju.composemediaplayer.presentation.util.showSystemUi
 
 @Composable
 fun VideoScreen(
@@ -34,11 +38,13 @@ fun VideoScreen(
 
     when(orientation) {
         ORIENTATION_PORTRAIT -> {
+            localContext.showSystemUi()
             VideoScreenBody(
                 player = serviceManager.playerService.player
             )
         }
         ORIENTATION_LANDSCAPE -> {
+            localContext.hideSystemUI()
             VideoScreenFullBody(
                 player = serviceManager.playerService.player
             )
@@ -55,8 +61,7 @@ fun VideoScreenBody(
             .fillMaxSize()
     ) {
         AndroidView(
-            factory = {
-                context ->
+            factory = { context ->
                 PlayerView(context).also {
                     it.player = player
                 }
@@ -77,15 +82,14 @@ fun VideoScreenFullBody(
             .fillMaxSize()
     ) {
         AndroidView(
-            factory = {
-                    context ->
+            factory = { context ->
                 PlayerView(context).also {
                     it.player = player
                 }
             },
             modifier = Modifier
-                .fillMaxWidth()
-                .aspectRatio(16 / 9f)
+                .fillMaxSize()
+                .background(Color.Black)
         )
     }
 }

--- a/app/src/main/java/com/seongju/composemediaplayer/presentation/util/FindActivity.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/presentation/util/FindActivity.kt
@@ -1,0 +1,12 @@
+package com.seongju.composemediaplayer.presentation.util
+
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
+
+fun Context.findActivity(): Activity? =
+    when(this) {
+        is Activity -> this
+        is ContextWrapper -> baseContext.findActivity()
+        else -> null
+    }

--- a/app/src/main/java/com/seongju/composemediaplayer/presentation/util/KeepScreenOn.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/presentation/util/KeepScreenOn.kt
@@ -1,0 +1,18 @@
+package com.seongju.composemediaplayer.presentation.util
+
+import android.view.View
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.viewinterop.AndroidView
+
+@Composable
+fun KeepScreenOn(
+    screenOnState: Boolean
+) {
+    AndroidView(
+        {
+            View(it).apply {
+                keepScreenOn = screenOnState
+            }
+        }
+    )
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/presentation/util/LockScreenOrientation.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/presentation/util/LockScreenOrientation.kt
@@ -1,0 +1,22 @@
+package com.seongju.composemediaplayer.presentation.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun LockScreenOrientation(orientation: Int) {
+    // ActivityInfo.SCREEN_ORIENTATION_PORTRAIT -> 세로 고정
+    // ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE -> 가로 고정
+    // ActivityInfo.SCREEN_ORIENTATION_SENSOR   -> 센서 사용
+    val context = LocalContext.current
+    DisposableEffect(Unit) {
+        val activity = context.findActivity()?: return@DisposableEffect onDispose {  }
+        val originalOrientation = activity.requestedOrientation
+        activity.requestedOrientation = orientation
+        onDispose {
+            // restore original orientation when view disappears
+            activity.requestedOrientation = originalOrientation
+        }
+    }
+}

--- a/app/src/main/java/com/seongju/composemediaplayer/presentation/util/SystemUiControl.kt
+++ b/app/src/main/java/com/seongju/composemediaplayer/presentation/util/SystemUiControl.kt
@@ -1,0 +1,24 @@
+package com.seongju.composemediaplayer.presentation.util
+
+import android.content.Context
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
+
+fun Context.hideSystemUI() {
+    val activity = this.findActivity() ?: return
+    val window = activity.window ?: return
+    WindowCompat.setDecorFitsSystemWindows(window, false)
+    WindowInsetsControllerCompat(window, window.decorView).let { controller ->
+        controller.hide(WindowInsetsCompat.Type.systemBars())
+        // 스와이프하면 SystemUI를 나타냄
+        controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+    }
+}
+
+fun Context.showSystemUi() {
+    val activity = this.findActivity() ?: return
+    val window = activity.window ?: return
+    WindowCompat.setDecorFitsSystemWindows(window, true)
+    WindowInsetsControllerCompat(window, window.decorView).show(WindowInsetsCompat.Type.systemBars())
+}

--- a/build.gradle
+++ b/build.gradle
@@ -7,5 +7,5 @@ plugins {
     id 'com.android.application' version '7.3.0' apply false
     id 'com.android.library' version '7.3.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
-    id 'com.google.dagger.hilt.android' version '2.42' apply false
+    id 'com.google.dagger.hilt.android' version '2.43.2' apply false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -7,4 +7,5 @@ plugins {
     id 'com.android.application' version '7.3.0' apply false
     id 'com.android.library' version '7.3.0' apply false
     id 'org.jetbrains.kotlin.android' version '1.8.10' apply false
+    id 'com.google.dagger.hilt.android' version '2.42' apply false
 }


### PR DESCRIPTION
service component 를 통해 video player 를 관리 -> 나중에 foregorund service 를 통해 background 작업을 할 수 있도록
service helper를 통한 player service 관리 -> IPC 통신 방법이 bind 해서 직접 가져오는 것 보다 훨신 안정적으로 명령을 주고 받을 수 있었음
세로모드일 때는 일반적인 16:9 비율의 작은 화면으로 영상을 재생하다가 가로모드일 때 전체화면으로 재생
홈 화면으로 이동 시 영상 일시중지. 바로 다시 돌아오면 재생 -> 단, 홈 화면에서 바로 돌아오지 않을 시 버퍼링은 사라짐